### PR TITLE
Clean up the pom file and update the grizzly framework version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
     Copyright (c) 2010, 2022 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -28,7 +29,7 @@
 
     <groupId>org.glassfish.grizzly</groupId>
     <artifactId>grizzly-memcached</artifactId>
-    <version>1.3.20-SNAPSHOT</version>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
 
     <name>grizzly-memcached</name>
@@ -49,9 +50,9 @@
             <id>carryel</id>
             <name>Bongjae Chang</name>
             <email>bongjae.chang@gmail.com</email>
-            <url>https://community.oracle.com/blogs/carryel</url>
+            <url>https://projects.eclipse.org/projects/ee4j.glassfish/CM/bchang</url>
             <organization>Kakao Corp.</organization>
-            <organizationUrl>http://www.kakaocorp.com/en/main</organizationUrl>
+            <organizationUrl>https://www.kakaocorp.com/page/?lang=ENG</organizationUrl>
         </developer>
     </developers>
 
@@ -63,20 +64,20 @@
     </mailingLists>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/grizzly-memcached.git</connection>
-        <developerConnection>scm:git:git@github.com:eclipse-ee4j/grizzly-memcached.git</developerConnection>
-        <url>https://github.com/eclipse-ee4j/grizzly-memcached</url>
+        <connection>scm:git:https://github.com/eclipse-ee4j/glassfish-grizzly-memcached.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse-ee4j/glassfish-grizzly-memcached.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/glassfish-grizzly-memcached</url>
         <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/eclipse-ee4j/grizzly-memcached/issues</url>
+        <url>https://github.com/eclipse-ee4j/glassfish-grizzly-memcached/issues</url>
     </issueManagement>
 
     <properties>
-        <grizzly-framework-version>2.4.4</grizzly-framework-version>
-        <zookeeper-version>3.7.2</zookeeper-version>
-        <jdk.compile.version>1.8</jdk.compile.version>
+        <grizzly-framework-version>4.0.2</grizzly-framework-version>
+        <zookeeper-version>3.9.3</zookeeper-version>
+        <jdk.compile.version>17</jdk.compile.version>
         <maven.compiler.argument>
             -Xlint:unchecked,deprecation,fallthrough,finally,cast,dep-ann,empty,overrides
         </maven.compiler.argument>
@@ -86,6 +87,11 @@
         <dependency>
             <groupId>org.glassfish.grizzly</groupId>
             <artifactId>grizzly-framework</artifactId>
+            <version>${grizzly-framework-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-framework-monitoring</artifactId>
             <version>${grizzly-framework-version}</version>
         </dependency>
         <dependency>
@@ -140,7 +146,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
                         <id>enforce-maven</id>
@@ -153,7 +159,7 @@
                                     <version>[${jdk.compile.version},)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.6.3</version>
+                                    <version>3.8.9</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>
@@ -163,10 +169,9 @@
 
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.14.0</version>
                 <configuration>
-                    <source>${jdk.compile.version}</source>
-                    <target>${jdk.compile.version}</target>
+                    <release>${jdk.compile.version}</release>
                     <compilerArgument>${maven.compiler.argument}</compilerArgument>
                 </configuration>
             </plugin>
@@ -174,10 +179,14 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.4</version>
+                <version>5.1.9</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
+                        <instructions>
+                            <_noimportjava>true</_noimportjava>
+                            <_runee>JavaSE-${jdk.compile.version}</_runee>
+                        </instructions>
                         <Import-Package>
                             org.glassfish.grizzly*;version=${project.version},
                             *,
@@ -192,14 +201,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.4.2</version>
                 <configuration>
                     <archive>
                         <manifestEntries>
                             <mode>development</mode>
                             <url>${project.url}</url>
-                            <implementation-version>${project.version}
-                            </implementation-version>
+                            <implementation-version>${project.version}</implementation-version>
                             <package>org.glassfish.grizzly</package>
                         </manifestEntries>
                     </archive>
@@ -209,22 +217,19 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.6.3</version>
                 <configuration>
-                    <javadocVersion>1.8</javadocVersion>
+                    <doclint>none</doclint>
                     <notimestamp>true</notimestamp>
                     <splitindex>true</splitindex>
                     <doctitle>${project.name} ${project.version}</doctitle>
-                    <additionalOptions>
-                        <additionalOption>-Xdoclint:none</additionalOption>
-                    </additionalOptions>
                 </configuration>
             </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -250,10 +255,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M5</version>
-                <configuration>
-                    <forkMode>always</forkMode>
-                </configuration>
+                <version>3.5.3</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/glassfish/grizzly/memcached/MemcachedClientFilter.java
+++ b/src/main/java/org/glassfish/grizzly/memcached/MemcachedClientFilter.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2012, 2017 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -27,7 +28,6 @@ import org.glassfish.grizzly.memcached.pool.ObjectPool;
 import org.glassfish.grizzly.memory.Buffers;
 import org.glassfish.grizzly.memory.CompositeBuffer;
 import org.glassfish.grizzly.memory.MemoryManager;
-import org.glassfish.grizzly.utils.NullaryFunction;
 
 import java.io.IOException;
 import java.net.SocketAddress;
@@ -36,6 +36,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -79,16 +80,18 @@ public class MemcachedClientFilter extends BaseFilter {
     private final Attribute<ParsingStatus> statusAttribute = Grizzly.DEFAULT_ATTRIBUTE_BUILDER.createAttribute("MemcachedClientFilter.Status");
     private final Attribute<MemcachedResponse> responseAttribute =
             Grizzly.DEFAULT_ATTRIBUTE_BUILDER.createAttribute("MemcachedClientFilter.Response",
-                    new NullaryFunction<MemcachedResponse>() {
-                        public MemcachedResponse evaluate() {
-                            return MemcachedResponse.create();
-                        }
-                    });
+                                                              new Supplier<MemcachedResponse>() {
+                                                                  @Override
+                                                                  public MemcachedResponse get() {
+                                                                      return MemcachedResponse.create();
+                                                                  }
+                                                              });
 
     private final Attribute<BlockingQueue<MemcachedRequest>> requestQueueAttribute =
-            Grizzly.DEFAULT_ATTRIBUTE_BUILDER.<BlockingQueue<MemcachedRequest>>createAttribute("MemcachedClientFilter.RequestQueue",
-                    new NullaryFunction<BlockingQueue<MemcachedRequest>>() {
-                        public BlockingQueue<MemcachedRequest> evaluate() {
+            Grizzly.DEFAULT_ATTRIBUTE_BUILDER.<BlockingQueue<MemcachedRequest>>createAttribute(
+                    "MemcachedClientFilter.RequestQueue", new Supplier<BlockingQueue<MemcachedRequest>>() {
+                        @Override
+                        public BlockingQueue<MemcachedRequest> get() {
                             return new LinkedTransferQueue<>();
                         }
                     });


### PR DESCRIPTION
+ Updated the major version of Grizzly framework (2.4.4 -> 4.0.2).
+ Changed the minimum java version to 17 or higher and upgraded the versions of other libraries.
+ Replaced the use of NullaryFunction, which has been removed since Grizzly framework 4.0.1, with Supplier (related issue https://github.com/eclipse-ee4j/grizzly/pull/2179).
+ Updated the minor version of grizzly-memcached (1.3.x -> 1.4.x).